### PR TITLE
add config (mode:'jit')

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  mode: 'jit',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
Este modo ayuda a solo usar estilos se generan a medida que construimos nuestros proyectos. Esto significa que sólo se incluirán en el tamaño de tu hoja de estilos las clases de utilidad que estés utilizando en ese momento, y no todas las clases de utilidad que vienen con Tailwind CSS.

**_Ventajas de utilizar el compilador JIT_:**

1. Tu hoja de estilo es la misma en [desarrollo](https://kinsta.com/es/base-de-conocimiento/editar-codigo-wordpress/) y en producción.
2. Tiempo de construcción más rápido.
3. Todas las variantes están activadas por defecto.
4. La compilación durante el desarrollo es mucho más rápida.
5. Sólo se generan los estilos utilizados.
6. Las variantes se pueden apilar.
7. Mejora del rendimiento de las herramientas de desarrollo.